### PR TITLE
T#76a08f: GE: Application crashes in DefensiveCheckScanState mid-game

### DIFF
--- a/code/Source/BaseTurn.cpp
+++ b/code/Source/BaseTurn.cpp
@@ -5,13 +5,14 @@ namespace Chess
 {
 
   void BaseTurn::deactivatePiece( ) 
-  { 
-    if(pendingRemovedPiece_) 
+  {
+    // Do not attempt to deactivate a Null Piece
+    if(pendingRemovedPiece_ && pendingRemovedPiece_->getName() != ".. ") 
     {
       int index = pendingRemovedPiece_->getActiveListIndex();
       pendingRemovedPiece_->clrActiveListIndex();
       activeList_.erase(activeList_.begin() + index);
-      pendingRemovedPiece_ = NULL;
+      pendingRemovedPiece_ = PiecePtr();
       updatePieceIndices();
     }
   }

--- a/code/Source/State/SwitchTurnState.cpp
+++ b/code/Source/State/SwitchTurnState.cpp
@@ -18,6 +18,10 @@ namespace Chess
       currentTurn_->getCausingCheckList().clear();
       currentTurn_->getPotentialPinList().clear();
       currentTurn_->getPinList().clear();
+      // Should not be needed, but for added protection we leave it in for now.
+      // This is worthy of reassessment during the next refactor.
+      whiteTurn_->setPendingRemovedPiece( PiecePtr() );
+      blackTurn_->setPendingRemovedPiece( PiecePtr() );
 
       interface_->printPinListDiagnostics();
 


### PR DESCRIPTION
- Verify that a "captured" piece is not a null piece before attempting to deactivate it.